### PR TITLE
Add address ingestion workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,10 @@ Thumbs.db
 # profiling data
 .prof
 
+# Local source files used to rebuild the packaged address dataset
+data/sources/
+data/work/
+
 # IDE
 .idea/
 

--- a/DATA_INGESTION.md
+++ b/DATA_INGESTION.md
@@ -5,6 +5,15 @@ address dataset.
 
 ## Use This Fork In Another Project
 
+For active local development from a consuming project's virtual environment:
+
+```powershell
+python -m pip install -e ..\random-address
+```
+
+Adjust `..\random-address` to the relative path from that project to this
+checkout.
+
 For a GitHub-pinned install:
 
 ```powershell
@@ -50,6 +59,9 @@ After a successful merge, run tests:
 ```powershell
 python -m pytest
 ```
+
+If you use a project-local virtual environment, keep it in `.venv/`; that path
+is ignored by git.
 
 Then commit and push:
 

--- a/DATA_INGESTION.md
+++ b/DATA_INGESTION.md
@@ -1,0 +1,60 @@
+# Data Ingestion Workflow
+
+This fork can be used directly by other projects while you expand the bundled
+address dataset.
+
+## Use This Fork In Another Project
+
+For a GitHub-pinned install:
+
+```powershell
+pip install "random-address @ git+https://github.com/alexagius/random-address.git@add-missing-state-data"
+```
+
+The import remains:
+
+```python
+import random_address
+```
+
+## Add Address Data
+
+Put raw source files under `data/sources/`. That directory is intentionally
+ignored by git, so large downloaded inputs do not end up in the package.
+
+The ingestion script accepts OpenAddresses-style CSV files, GeoJSON
+FeatureCollections, and newline-delimited GeoJSON Features:
+
+```powershell
+python data\ingest_addresses.py `
+  --input data\sources\ny-addresses.csv `
+  --state NY `
+  --attribution "Source Name (NY)" `
+  --per-postal-code 5 `
+  --limit 500
+```
+
+Useful options:
+
+- `--dry-run`: print the incoming and merged counts without writing the package
+  dataset.
+- `--per-postal-code N`: keep up to `N` addresses per ZIP code.
+- `--limit N`: cap the total incoming addresses after ZIP sampling.
+- `--replace-state`: remove existing records for the state before adding new
+  records.
+- `--pretty`: write readable JSON when inspecting output. Leave this off for the
+  minified package file.
+
+After a successful merge, run tests:
+
+```powershell
+python -m pytest
+```
+
+Then commit and push:
+
+```powershell
+git add data\ingest_addresses.py tests\test_ingest_addresses.py DATA_INGESTION.md random_address\addresses-us-all.min.json
+git commit -m "Add address ingestion workflow"
+git push
+```

--- a/data/ingest_addresses.py
+++ b/data/ingest_addresses.py
@@ -1,0 +1,387 @@
+"""Ingest OpenAddresses-style source files into the packaged dataset.
+
+This script is intentionally dependency-free so it can run in a fresh checkout.
+It supports OpenAddresses CSV exports, GeoJSON FeatureCollections, and newline-
+delimited GeoJSON Features.
+"""
+
+import argparse
+import csv
+import json
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DATASET = ROOT / "random_address" / "addresses-us-all.min.json"
+VALID_STATES = {
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL",
+    "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME",
+    "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH",
+    "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI",
+    "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI",
+    "WY",
+}
+
+
+Address = Dict[str, Any]
+
+
+def load_dataset(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as source_file:
+        data = json.load(source_file)
+    data.setdefault("addresses", [])
+    data.setdefault("attribution", [])
+    return data
+
+
+def write_dataset(path: Path, data: Dict[str, Any], pretty: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as target_file:
+        if pretty:
+            json.dump(data, target_file, indent=2)
+            target_file.write("\n")
+        else:
+            json.dump(data, target_file, separators=(",", ":"))
+
+
+def detect_format(path: Path, requested_format: str) -> str:
+    if requested_format != "auto":
+        return requested_format
+    if path.suffix.lower() == ".csv":
+        return "csv"
+    return "geojson"
+
+
+def iter_source_records(path: Path, source_format: str) -> Iterator[Dict[str, Any]]:
+    if source_format == "csv":
+        yield from iter_csv_records(path)
+    elif source_format == "geojson":
+        yield from iter_geojson_records(path)
+    else:
+        raise ValueError(f"Unsupported source format: {source_format}")
+
+
+def iter_csv_records(path: Path) -> Iterator[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as source_file:
+        reader = csv.DictReader(source_file)
+        for row in reader:
+            yield {"properties": row, "coordinates": csv_coordinates(row)}
+
+
+def csv_coordinates(row: Dict[str, str]) -> Optional[Tuple[float, float]]:
+    lon = first_present(row, ("LON", "lon", "LONGITUDE", "longitude", "lng"))
+    lat = first_present(row, ("LAT", "lat", "LATITUDE", "latitude"))
+    if lon is None or lat is None:
+        return None
+    return to_float(lon), to_float(lat)
+
+
+def iter_geojson_records(path: Path) -> Iterator[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8-sig") as source_file:
+        first_line = source_file.readline()
+        if not first_line:
+            return
+
+        source_file.seek(0)
+        try:
+            parsed = json.load(source_file)
+        except json.JSONDecodeError:
+            source_file.seek(0)
+            for line in source_file:
+                line = line.strip()
+                if line:
+                    yield geojson_record(json.loads(line))
+            return
+
+    if parsed.get("type") == "FeatureCollection":
+        for feature in parsed.get("features", []):
+            yield geojson_record(feature)
+        return
+    if parsed.get("type") == "Feature":
+        yield geojson_record(parsed)
+
+
+def geojson_record(feature: Dict[str, Any]) -> Dict[str, Any]:
+    geometry = feature.get("geometry") or {}
+    coordinates = geometry.get("coordinates") or []
+    lon = coordinates[0] if len(coordinates) > 0 else None
+    lat = coordinates[1] if len(coordinates) > 1 else None
+    return {
+        "properties": feature.get("properties") or {},
+        "coordinates": (
+            (to_float(lon), to_float(lat))
+            if lon is not None and lat is not None
+            else None
+        ),
+    }
+
+
+def normalize_record(
+    record: Dict[str, Any],
+    state: str,
+    city_fallback: Optional[str] = None,
+) -> Optional[Address]:
+    properties = record.get("properties") or {}
+    number = clean_value(first_present(properties, ("NUMBER", "number", "addr:housenumber")))
+    street = clean_value(first_present(properties, ("STREET", "street", "addr:street")))
+    unit = clean_value(first_present(properties, ("UNIT", "unit", "addr:unit")))
+    city = clean_value(first_present(properties, ("CITY", "city", "addr:city"))) or city_fallback
+    postcode = clean_postal_code(
+        first_present(properties, ("POSTCODE", "postcode", "ZIP", "zip", "addr:postcode"))
+    )
+    coordinates = record.get("coordinates")
+
+    if not street or not postcode or not coordinates:
+        return None
+
+    address1 = f"{number} {street}".strip() if number else street
+    lon, lat = coordinates
+    if lon is None or lat is None:
+        return None
+
+    return {
+        "address1": address1,
+        "address2": unit or "",
+        "city": city or "",
+        "state": state,
+        "postalCode": postcode,
+        "coordinates": {
+            "lat": lat,
+            "lng": lon,
+        },
+    }
+
+
+def first_present(values: Dict[str, Any], keys: Sequence[str]) -> Optional[Any]:
+    lower_lookup = {key.lower(): value for key, value in values.items()}
+    for key in keys:
+        if key in values and values[key] not in (None, ""):
+            return values[key]
+        lower_key = key.lower()
+        if lower_key in lower_lookup and lower_lookup[lower_key] not in (None, ""):
+            return lower_lookup[lower_key]
+    return None
+
+
+def clean_value(value: Optional[Any]) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).strip().split())
+
+
+def clean_postal_code(value: Optional[Any]) -> str:
+    cleaned = clean_value(value)
+    if not cleaned:
+        return ""
+    if "-" in cleaned:
+        return cleaned.split("-", 1)[0]
+    return cleaned
+
+
+def to_float(value: Any) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def address_key(address: Address) -> Tuple[str, str, str, str, str]:
+    return (
+        clean_value(address.get("address1")).lower(),
+        clean_value(address.get("address2")).lower(),
+        clean_value(address.get("city")).lower(),
+        clean_value(address.get("state")).upper(),
+        clean_value(address.get("postalCode")),
+    )
+
+
+def sample_addresses(
+    addresses: Sequence[Address],
+    limit: Optional[int],
+    per_postal_code: Optional[int],
+    seed: int,
+) -> List[Address]:
+    selected = list(addresses)
+    rng = random.Random(seed)
+
+    if per_postal_code is not None:
+        by_postal_code: Dict[str, List[Address]] = defaultdict(list)
+        for address in selected:
+            by_postal_code[address["postalCode"]].append(address)
+        selected = []
+        for postal_code in sorted(by_postal_code):
+            candidates = by_postal_code[postal_code]
+            rng.shuffle(candidates)
+            selected.extend(candidates[:per_postal_code])
+
+    if limit is not None and len(selected) > limit:
+        selected = rng.sample(selected, limit)
+
+    return sorted(
+        selected,
+        key=lambda address: (
+            address["state"],
+            address["postalCode"],
+            address["city"],
+            address["address1"],
+            address["address2"],
+        ),
+    )
+
+
+def dedupe_addresses(base: Sequence[Address], incoming: Sequence[Address]) -> List[Address]:
+    seen = {address_key(address) for address in base}
+    deduped = []
+    for address in incoming:
+        key = address_key(address)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(address)
+    return deduped
+
+
+def load_new_addresses(args: argparse.Namespace) -> List[Address]:
+    state = args.state.upper()
+    if state not in VALID_STATES:
+        raise ValueError(f"Unsupported state code: {state}")
+
+    addresses = []
+    for source_path in args.input:
+        source_format = detect_format(source_path, args.format)
+        for record in iter_source_records(source_path, source_format):
+            address = normalize_record(record, state=state, city_fallback=args.city)
+            if address is not None:
+                addresses.append(address)
+
+    return sample_addresses(
+        addresses,
+        limit=args.limit,
+        per_postal_code=args.per_postal_code,
+        seed=args.seed,
+    )
+
+
+def merge_dataset(
+    args: argparse.Namespace,
+    incoming: Optional[Sequence[Address]] = None,
+) -> Dict[str, Any]:
+    data = load_dataset(args.base)
+    existing_addresses = data["addresses"]
+    existing_attribution = data["attribution"]
+    incoming = list(incoming) if incoming is not None else load_new_addresses(args)
+
+    if args.replace_state:
+        existing_addresses = [
+            address
+            for address in existing_addresses
+            if address.get("state") != args.state.upper()
+        ]
+
+    incoming = dedupe_addresses(existing_addresses, incoming)
+    data["addresses"] = existing_addresses + incoming
+
+    if args.attribution and args.attribution not in existing_attribution:
+        data["attribution"] = existing_attribution + [args.attribution]
+
+    return data
+
+
+def summarize(addresses: Iterable[Address]) -> Dict[str, Any]:
+    address_list = list(addresses)
+    states = Counter(address.get("state") for address in address_list)
+    postals = Counter(address.get("postalCode") for address in address_list)
+    return {
+        "addresses": len(address_list),
+        "states": dict(sorted(states.items())),
+        "postal_codes": len(postals),
+    }
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge OpenAddresses-style source data into addresses-us-all.min.json."
+    )
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="Source CSV, GeoJSON FeatureCollection, or newline-delimited GeoJSON file(s).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("auto", "csv", "geojson"),
+        default="auto",
+        help="Source format. Defaults to extension-based auto detection.",
+    )
+    parser.add_argument("--state", required=True, help="Two-letter state code for the source data.")
+    parser.add_argument("--city", help="Fallback city when the source does not provide one.")
+    parser.add_argument("--attribution", help="Attribution text to append to the dataset.")
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=DEFAULT_DATASET,
+        help=f"Existing dataset to merge into. Defaults to {DEFAULT_DATASET}.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_DATASET,
+        help=f"Output dataset path. Defaults to {DEFAULT_DATASET}.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of incoming addresses after per-ZIP sampling.",
+    )
+    parser.add_argument(
+        "--per-postal-code",
+        type=int,
+        help="Maximum number of incoming addresses to keep per postal code.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=20260512,
+        help="Random seed used for reproducible sampling.",
+    )
+    parser.add_argument(
+        "--replace-state",
+        action="store_true",
+        help="Remove existing addresses for this state before adding incoming records.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Write formatted JSON instead of the package's minified JSON.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the merge summary without writing the output file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    new_addresses = load_new_addresses(args)
+    merged = merge_dataset(args, incoming=new_addresses)
+
+    print("Incoming:", json.dumps(summarize(new_addresses), sort_keys=True))
+    print("Merged:", json.dumps(summarize(merged["addresses"]), sort_keys=True))
+
+    if not args.dry_run:
+        write_dataset(args.output, merged, pretty=args.pretty)
+        print(f"Wrote {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ingest_addresses.py
+++ b/tests/test_ingest_addresses.py
@@ -1,0 +1,169 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "data" / "ingest_addresses.py"
+SPEC = importlib.util.spec_from_file_location("ingest_addresses", SCRIPT_PATH)
+ingest_addresses = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ingest_addresses)
+
+
+def test_normalize_csv_openaddresses_row():
+    record = {
+        "properties": {
+            "NUMBER": "123",
+            "STREET": "Main Street",
+            "UNIT": "2A",
+            "CITY": "Albany",
+            "POSTCODE": "12207-1234",
+            "LON": "-73.7562",
+            "LAT": "42.6526",
+        },
+        "coordinates": (-73.7562, 42.6526),
+    }
+
+    address = ingest_addresses.normalize_record(record, state="NY")
+
+    assert address == {
+        "address1": "123 Main Street",
+        "address2": "2A",
+        "city": "Albany",
+        "state": "NY",
+        "postalCode": "12207",
+        "coordinates": {
+            "lat": 42.6526,
+            "lng": -73.7562,
+        },
+    }
+
+
+def test_merge_dataset_dedupes_and_appends_attribution(tmp_path):
+    base = tmp_path / "base.json"
+    output = tmp_path / "output.json"
+    source = tmp_path / "source.geojson"
+
+    existing = {
+        "addresses": [
+            {
+                "address1": "123 Main Street",
+                "address2": "",
+                "city": "Albany",
+                "state": "NY",
+                "postalCode": "12207",
+                "coordinates": {"lat": 42.6526, "lng": -73.7562},
+            }
+        ],
+        "attribution": [],
+    }
+    base.write_text(json.dumps(existing), encoding="utf-8")
+
+    features = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {
+                    "number": "123",
+                    "street": "Main Street",
+                    "city": "Albany",
+                    "postcode": "12207",
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-73.7562, 42.6526],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {
+                    "number": "456",
+                    "street": "State Street",
+                    "city": "Albany",
+                    "postcode": "12207",
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-73.75, 42.65],
+                },
+            },
+        ],
+    }
+    source.write_text(json.dumps(features), encoding="utf-8")
+
+    args = ingest_addresses.parse_args(
+        [
+            "--input",
+            str(source),
+            "--state",
+            "NY",
+            "--base",
+            str(base),
+            "--output",
+            str(output),
+            "--attribution",
+            "Example County (NY)",
+        ]
+    )
+
+    merged = ingest_addresses.merge_dataset(args)
+
+    assert len(merged["addresses"]) == 2
+    assert merged["addresses"][1]["address1"] == "456 State Street"
+    assert merged["attribution"] == ["Example County (NY)"]
+
+
+def test_newline_delimited_geojson_source(tmp_path):
+    source = tmp_path / "source.geojson"
+    features = [
+        {
+            "type": "Feature",
+            "properties": {
+                "number": "1",
+                "street": "Main Street",
+                "city": "Albany",
+                "postcode": "12207",
+            },
+            "geometry": {"type": "Point", "coordinates": [-73.7562, 42.6526]},
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "number": "2",
+                "street": "State Street",
+                "city": "Albany",
+                "postcode": "12207",
+            },
+            "geometry": {"type": "Point", "coordinates": [-73.75, 42.65]},
+        },
+    ]
+    source.write_text("\n".join(json.dumps(feature) for feature in features), encoding="utf-8")
+
+    records = list(ingest_addresses.iter_geojson_records(source))
+
+    assert len(records) == 2
+    assert records[1]["properties"]["street"] == "State Street"
+
+
+def test_per_postal_code_sampling_is_reproducible():
+    addresses = [
+        {
+            "address1": f"{index} Main Street",
+            "address2": "",
+            "city": "Albany",
+            "state": "NY",
+            "postalCode": "12207",
+            "coordinates": {"lat": 42.0, "lng": -73.0},
+        }
+        for index in range(10)
+    ]
+
+    first = ingest_addresses.sample_addresses(
+        addresses, limit=None, per_postal_code=3, seed=42
+    )
+    second = ingest_addresses.sample_addresses(
+        addresses, limit=None, per_postal_code=3, seed=42
+    )
+
+    assert first == second
+    assert len(first) == 3


### PR DESCRIPTION
Adds a reusable ingestion workflow for expanding the bundled address dataset.

Changes:
- Adds a dependency-free ingestion CLI for OpenAddresses-style CSV and GeoJSON files.
- Supports sampling, per-ZIP limits, deduplication, attribution, and dry runs.
- Adds tests for parsing, merging, deduplication, and sampling.
- Documents how to use the fork from other projects and how to add source data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added address data ingestion capability supporting multiple input formats (CSV, GeoJSON) with deduplication, sampling, and state/attribution management options.

* **Documentation**
  * Added comprehensive guide for the address data ingestion workflow, including installation, usage instructions, and CLI options.

* **Tests**
  * Added test coverage for data normalization, merging, and sampling functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neosergio/random-address/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->