### PR TITLE
Type-check the whole project and tighten the release guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: ruff check .
       - run: ruff format --check .
+      # The package ships py.typed, which promises downstream users working
+      # type hints. Nothing but this step holds us to that promise.
+      - run: mypy
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,23 +35,29 @@ jobs:
         with:
           python-version: "3.13"
 
+      # The version is declared twice: pyproject.toml decides what PyPI
+      # publishes, and __version__ is what `random-address --version` reports.
+      # Bumping one and not the other ships a package that misreports itself,
+      # so the release tag has to agree with both.
       - name: Check the release tag matches the package version
         if: github.event_name == 'release'
         run: |
           set -euo pipefail
+          pip install -e .
           tag="${GITHUB_REF_NAME#v}"
           version=$(python -c \
             "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          if [ "$tag" != "$version" ]; then
-            echo "::error::Release tag is v$tag but pyproject.toml says $version."
-            echo "PyPI would publish $version, not what the release claims. Fix one of them."
+          dunder=$(python -c "import random_address; print(random_address.__version__)")
+          if [ "$tag" != "$version" ] || [ "$tag" != "$dunder" ]; then
+            echo "::error::Release tag is v$tag, pyproject.toml says $version, __version__ says $dunder."
+            echo "PyPI would publish $version, and the CLI would report $dunder. Fix them so all three agree."
             exit 1
           fi
-          echo "Tag v$tag matches package version $version."
+          echo "Tag v$tag matches pyproject.toml and __version__."
 
       - run: pip install build twine
       - run: python -m build
-      - run: twine check dist/*
+      - run: twine check --strict dist/*
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/data/add_addresses.py
+++ b/data/add_addresses.py
@@ -24,9 +24,9 @@ import random
 import re
 import sys
 from collections import Counter, defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeGuard
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATASET = REPO_ROOT / "src" / "random_address" / "data" / "addresses-us.jsonl"
@@ -449,7 +449,9 @@ def normalize_street(street: str) -> str:
     return titlecase(" ".join(tokens))
 
 
-def _valid_coordinates(coordinates: Any) -> bool:
+def _valid_coordinates(coordinates: Any) -> TypeGuard[Sequence[float]]:
+    # A TypeGuard rather than a bool: the caller indexes the coordinates right
+    # after this returns true, and only the guard establishes that it may.
     if not isinstance(coordinates, (list, tuple)) or len(coordinates) < 2:
         return False
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "build>=1.2",
+    "mypy>=1.11",
     "pytest>=8",
     "ruff>=0.6",
     "twine>=6",
@@ -83,6 +84,11 @@ addopts = [
     "-ra",
     "-q",
 ]
+# The package has no runtime dependencies, so every warning raised during a test
+# run comes from this code or from the standard library deprecating something out
+# from under it. A DeprecationWarning here is the 3.14 job failing early, quietly,
+# where nobody reads it; make it fail loudly instead.
+filterwarnings = ["error"]
 
 
 [tool.ruff]
@@ -100,3 +106,12 @@ select = [
     "SIM",  # flake8-simplify
     "RUF",  # ruff-specific
 ]
+
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src", "tests", "data"]
+# data/ holds the maintainer ingest script, which the dataset tests import.
+# pytest finds it through pythonpath above; mypy needs telling separately.
+mypy_path = "data"
+strict = true

--- a/src/random_address/_dataset.py
+++ b/src/random_address/_dataset.py
@@ -13,12 +13,21 @@ rewritten 500 KB line.
 from __future__ import annotations
 
 import json
+import sys
 from collections import defaultdict
 from functools import cache
 from importlib import resources
 from typing import Literal, TypeAlias
 
 from .types import Address
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:
+    # importlib.resources.abc does not exist before 3.11, and importlib.abc
+    # is deprecated and removed in 3.14. Neither spelling covers the whole
+    # supported range, so each version imports from where it still works.
+    from importlib.abc import Traversable
 
 DATA_FILE = ("data", "addresses-us.jsonl")
 
@@ -41,14 +50,29 @@ def normalize(field: Field, value: str) -> str:
     return value.strip()
 
 
+def data_source() -> Traversable:
+    """Return the bundled dataset file.
+
+    Traversable.joinpath only takes several children from 3.11 on, and a
+    zip-imported package gets a Traversable rather than a Path, so the components
+    are descended one at a time: every version and every loader agrees on that.
+    Both the loader and the dataset integrity tests come through here, so the
+    walk is written once.
+    """
+    source = resources.files(__package__)
+    for part in DATA_FILE:
+        source = source.joinpath(part)
+
+    return source
+
+
 @cache
 def load_addresses() -> tuple[Address, ...]:
     """Return every address in the bundled dataset.
 
     The result is cached, so the file is parsed only on the first call.
     """
-    source = resources.files(__package__).joinpath(*DATA_FILE)
-    with source.open("r", encoding="utf-8") as handle:
+    with data_source().open("r", encoding="utf-8") as handle:
         return tuple(json.loads(line) for line in handle if line.strip())
 
 

--- a/src/random_address/cli.py
+++ b/src/random_address/cli.py
@@ -7,7 +7,7 @@ import csv
 import io
 import json
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from . import __version__
 from .core import (
@@ -145,7 +145,9 @@ def _handle_get(args: argparse.Namespace) -> str:
     return "\n".join(_to_text(address) for address in addresses)
 
 
-def _make_listing_handler(counts):
+def _make_listing_handler(
+    counts: Callable[[], dict[str, int]],
+) -> Callable[[argparse.Namespace], str]:
     def handler(args: argparse.Namespace) -> str:
         values = counts()
         if args.format == "json":

--- a/src/random_address/core.py
+++ b/src/random_address/core.py
@@ -162,11 +162,12 @@ def _pool(
     postal_code: str | None,
 ) -> tuple[Address, ...]:
     """Return every address matching all of the filters that were supplied."""
-    active: dict[Field, str] = {
-        field: value
-        for field, value in (("state", state), ("city", city), ("postal_code", postal_code))
-        if value is not None
-    }
+    supplied: tuple[tuple[Field, str | None], ...] = (
+        ("state", state),
+        ("city", city),
+        ("postal_code", postal_code),
+    )
+    active: dict[Field, str] = {field: value for field, value in supplied if value is not None}
     if not active:
         return _dataset.load_addresses()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,24 @@ failure.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
+from typing import Protocol
 
 import pytest
 
 from random_address import _dataset
 from random_address.types import Address
+
+
+class InstallDataset(Protocol):
+    """What the ``dataset`` fixture hands a test.
+
+    A Protocol rather than Callable[..., None]: the ellipsis accepts any
+    arguments at all, so a test that installed something which was not an
+    Address would type-check happily. This pins the real signature.
+    """
+
+    def __call__(self, *addresses: Address) -> None: ...
 
 
 def address(
@@ -38,7 +50,7 @@ def address(
 
 
 @pytest.fixture
-def dataset(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., None]]:
+def dataset(monkeypatch: pytest.MonkeyPatch) -> Iterator[InstallDataset]:
     """Replace the bundled dataset for the duration of a test."""
 
     def install(*addresses: Address) -> None:

--- a/tests/test_add_addresses.py
+++ b/tests/test_add_addresses.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import random
+from typing import Any
 
 import pytest
 from add_addresses import (
@@ -22,12 +23,17 @@ from add_addresses import (
 )
 
 
-def options(**overrides) -> argparse.Namespace:
-    defaults = {"state": "NC", "city": None, "allow_missing_city": False, "city_map": {}}
+def options(**overrides: Any) -> argparse.Namespace:
+    defaults: dict[str, Any] = {
+        "state": "NC",
+        "city": None,
+        "allow_missing_city": False,
+        "city_map": {},
+    }
     return argparse.Namespace(**{**defaults, **overrides})
 
 
-def feature(**properties) -> dict:
+def feature(**properties: str) -> dict[str, Any]:
     defaults = {
         "number": "212",
         "street": "HERON CT SW",
@@ -145,14 +151,16 @@ class TestConvert:
         address, reason = _convert(feature(), options())
 
         assert reason == ""
+        assert address is not None
         assert address["address1"] == "212 Heron Court Southwest"
         assert address["city"] == "Bolivia"
         assert address["state"] == "NC"
         assert address["postal_code"] == "28422"
 
     def test_truncates_zip_plus_four(self) -> None:
-        address, _ = _convert(feature(postcode="28422-1234"), options())
+        address, reason = _convert(feature(postcode="28422-1234"), options())
 
+        assert address is not None, reason
         assert address["postal_code"] == "28422"
 
     @pytest.mark.parametrize(
@@ -165,7 +173,11 @@ class TestConvert:
             ({"street": ""}, "no street address"),
         ],
     )
-    def test_rejects_unusable_records(self, overrides: dict, reason: str) -> None:
+    def test_rejects_unusable_records(
+        self,
+        overrides: dict[str, str],
+        reason: str,
+    ) -> None:
         address, actual = _convert(feature(**overrides), options())
 
         assert address is None
@@ -178,21 +190,24 @@ class TestConvert:
         assert reason == "state is CA, not NC"
 
     def test_city_option_fills_in_a_source_that_omits_it(self) -> None:
-        address, _ = _convert(feature(city=""), options(city="Arlington"))
+        address, reason = _convert(feature(city=""), options(city="Arlington"))
 
+        assert address is not None, reason
         assert address["city"] == "Arlington"
 
     def test_city_map_expands_a_source_that_publishes_codes(self) -> None:
-        address, _ = _convert(
+        address, reason = _convert(
             feature(city="DURH"),
             options(city_map={"DURH": "Durham", "CHAP": "Chapel Hill"}),
         )
 
+        assert address is not None, reason
         assert address["city"] == "Durham"
 
     def test_city_map_preserves_names_it_does_not_cover(self) -> None:
-        address, _ = _convert(feature(city="BOLIVIA"), options(city_map={"DURH": "Durham"}))
+        address, reason = _convert(feature(city="BOLIVIA"), options(city_map={"DURH": "Durham"}))
 
+        assert address is not None, reason
         assert address["city"] == "Bolivia"
 
     def test_rejects_a_corrupt_city_with_no_letters_in_it(self) -> None:
@@ -203,8 +218,9 @@ class TestConvert:
         assert reason == "no city"
 
     def test_allow_missing_city_still_works(self) -> None:
-        address, _ = _convert(feature(city=""), options(allow_missing_city=True))
+        address, reason = _convert(feature(city=""), options(allow_missing_city=True))
 
+        assert address is not None, reason
         assert address["city"] == ""
 
     def test_rejects_coordinates_outside_the_us(self) -> None:
@@ -218,7 +234,7 @@ class TestConvert:
 
 
 class TestKey:
-    def address(self, **overrides) -> dict:
+    def address(self, **overrides: str) -> dict[str, Any]:
         base = {
             "state": "NC",
             "postal_code": "27701",
@@ -277,7 +293,7 @@ class TestAllocate:
 
 
 class TestBalancedSample:
-    def addresses(self, city: str, n: int) -> list[dict]:
+    def addresses(self, city: str, n: int) -> list[dict[str, Any]]:
         return [{"city": city, "address1": f"{i} Main Street"} for i in range(n)]
 
     def test_splits_the_count_across_the_named_cities(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 
 from random_address.cli import main
 
-from .conftest import address
+from .conftest import InstallDataset, address
 
 
 def run(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str, str]:
@@ -19,30 +19,34 @@ def run(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str, str]:
 
 
 class TestGet:
-    def test_bare_invocation_prints_one_address(self, capsys) -> None:
+    def test_bare_invocation_prints_one_address(self, capsys: pytest.CaptureFixture[str]) -> None:
         code, out, _ = run(capsys)
 
         assert code == 0
         assert len(out.splitlines()) == 1
 
-    def test_filters_without_naming_the_get_command(self, capsys) -> None:
+    def test_filters_without_naming_the_get_command(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         code, out, _ = run(capsys, "--state", "CA")
 
         assert code == 0
         assert ", CA " in out
 
-    def test_count_prints_one_address_per_line(self, capsys) -> None:
+    def test_count_prints_one_address_per_line(self, capsys: pytest.CaptureFixture[str]) -> None:
         _, out, _ = run(capsys, "--state", "FL", "--count", "3")
 
         assert len(out.splitlines()) == 3
 
-    def test_seed_makes_output_reproducible(self, capsys) -> None:
+    def test_seed_makes_output_reproducible(self, capsys: pytest.CaptureFixture[str]) -> None:
         _, first, _ = run(capsys, "--seed", "42", "--count", "3")
         _, second, _ = run(capsys, "--seed", "42", "--count", "3")
 
         assert first == second
 
-    def test_json_format_emits_an_object_for_a_single_address(self, capsys) -> None:
+    def test_json_format_emits_an_object_for_a_single_address(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         _, out, _ = run(capsys, "--format", "json", "--state", "CA")
 
         payload = json.loads(out)
@@ -50,7 +54,9 @@ class TestGet:
         assert isinstance(payload, dict)
         assert payload["state"] == "CA"
 
-    def test_json_format_emits_an_array_for_several_addresses(self, capsys) -> None:
+    def test_json_format_emits_an_array_for_several_addresses(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         _, out, _ = run(capsys, "--format", "json", "--count", "2")
 
         payload = json.loads(out)
@@ -58,7 +64,9 @@ class TestGet:
         assert isinstance(payload, list)
         assert len(payload) == 2
 
-    def test_csv_format_has_a_header_and_a_row_per_address(self, capsys) -> None:
+    def test_csv_format_has_a_header_and_a_row_per_address(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         _, out, _ = run(capsys, "--format", "csv", "--count", "2")
 
         lines = out.splitlines()
@@ -66,7 +74,9 @@ class TestGet:
         assert lines[0] == "address1,address2,city,state,postal_code,lat,lng"
         assert len(lines) == 3
 
-    def test_repeat_allows_more_addresses_than_exist(self, capsys, dataset) -> None:
+    def test_repeat_allows_more_addresses_than_exist(
+        self, capsys: pytest.CaptureFixture[str], dataset: InstallDataset
+    ) -> None:
         dataset(address())
 
         code, out, _ = run(capsys, "--count", "3", "--repeat")
@@ -74,14 +84,14 @@ class TestGet:
         assert code == 0
         assert len(out.splitlines()) == 3
 
-    def test_unknown_filter_reports_an_error(self, capsys) -> None:
+    def test_unknown_filter_reports_an_error(self, capsys: pytest.CaptureFixture[str]) -> None:
         code, out, err = run(capsys, "--state", "ZZ")
 
         assert code == 1
         assert out == ""
         assert "No address matches" in err
 
-    def test_negative_count_reports_an_error(self, capsys) -> None:
+    def test_negative_count_reports_an_error(self, capsys: pytest.CaptureFixture[str]) -> None:
         code, _, err = run(capsys, "--count", "-1")
 
         assert code == 2
@@ -90,20 +100,22 @@ class TestGet:
 
 class TestListings:
     @pytest.mark.parametrize("command", ["states", "cities", "postal-codes"])
-    def test_text_listing_pairs_each_value_with_a_count(self, capsys, command: str) -> None:
+    def test_text_listing_pairs_each_value_with_a_count(
+        self, capsys: pytest.CaptureFixture[str], command: str
+    ) -> None:
         code, out, _ = run(capsys, command)
 
         assert code == 0
         assert all(line.split()[-1].isdigit() for line in out.splitlines())
 
-    def test_json_listing_maps_values_to_counts(self, capsys) -> None:
+    def test_json_listing_maps_values_to_counts(self, capsys: pytest.CaptureFixture[str]) -> None:
         _, out, _ = run(capsys, "states", "--format", "json")
 
         payload = json.loads(out)
 
         assert payload["CA"] > 0
 
-    def test_summary_reports_the_dataset_totals(self, capsys) -> None:
+    def test_summary_reports_the_dataset_totals(self, capsys: pytest.CaptureFixture[str]) -> None:
         _, out, _ = run(capsys, "summary", "--format", "json")
 
         payload = json.loads(out)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,7 @@ from random_address import (
     summary,
 )
 
-from .conftest import address
+from .conftest import InstallDataset, address
 
 ADDRESS_FIELDS = {"address1", "address2", "city", "state", "postal_code", "coordinates"}
 
@@ -43,7 +43,7 @@ class TestRealRandomAddress:
     def test_filters_by_postal_code(self) -> None:
         assert real_random_address(postal_code="94560")["postal_code"] == "94560"
 
-    def test_filters_combine(self, dataset) -> None:
+    def test_filters_combine(self, dataset: InstallDataset) -> None:
         dataset(
             address(state="CA", city="Newark", address1="wanted"),
             address(state="CA", city="Fresno", address1="wrong city"),
@@ -65,13 +65,13 @@ class TestRealRandomAddress:
         with pytest.raises(NoMatchingAddressError, match="state='ZZ'"):
             real_random_address(state="ZZ")
 
-    def test_contradictory_filters_raise(self, dataset) -> None:
+    def test_contradictory_filters_raise(self, dataset: InstallDataset) -> None:
         dataset(address(state="CA", city="Newark"))
 
         with pytest.raises(NoMatchingAddressError):
             real_random_address(state="FL", city="Newark")
 
-    def test_empty_dataset_raises_instead_of_crashing(self, dataset) -> None:
+    def test_empty_dataset_raises_instead_of_crashing(self, dataset: InstallDataset) -> None:
         dataset()
 
         # v1 raised IndexError here, contradicting its own documented contract.
@@ -109,20 +109,20 @@ class TestRealRandomAddresses:
         with pytest.raises(ValueError, match="must not be negative"):
             real_random_addresses(-1)
 
-    def test_results_are_distinct_by_default(self, dataset) -> None:
+    def test_results_are_distinct_by_default(self, dataset: InstallDataset) -> None:
         dataset(*(address(address1=f"{n} Main Street") for n in range(10)))
 
         results = real_random_addresses(10)
 
         assert len({result["address1"] for result in results}) == 10
 
-    def test_requesting_more_than_exist_raises(self, dataset) -> None:
+    def test_requesting_more_than_exist_raises(self, dataset: InstallDataset) -> None:
         dataset(address(), address())
 
         with pytest.raises(NoMatchingAddressError, match="Only 2 distinct addresses"):
             real_random_addresses(3)
 
-    def test_repeats_are_allowed_when_unique_is_false(self, dataset) -> None:
+    def test_repeats_are_allowed_when_unique_is_false(self, dataset: InstallDataset) -> None:
         dataset(address())
 
         assert len(real_random_addresses(4, unique=False)) == 4
@@ -152,7 +152,7 @@ class TestDatasetIntrospection:
         assert list_cities() == list(city_counts())
         assert list_postal_codes() == list(postal_code_counts())
 
-    def test_counts_add_up_to_the_dataset_size(self, dataset) -> None:
+    def test_counts_add_up_to_the_dataset_size(self, dataset: InstallDataset) -> None:
         dataset(
             address(state="CA"),
             address(state="CA"),
@@ -161,7 +161,7 @@ class TestDatasetIntrospection:
 
         assert state_counts() == {"CA": 2, "FL": 1}
 
-    def test_blank_values_are_left_out_of_listings(self, dataset) -> None:
+    def test_blank_values_are_left_out_of_listings(self, dataset: InstallDataset) -> None:
         # 20 records in the bundled dataset have no city at all.
         dataset(address(city="Newark"), address(city=""))
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -19,13 +19,18 @@ from __future__ import annotations
 import json
 import re
 from collections import Counter
-from importlib import resources
 from math import isfinite
+from typing import Any, TypeAlias
 
 import pytest
 from add_addresses import DIRECTIONALS, STREET_SUFFIXES, normalize_street
 
-from random_address._dataset import DATA_FILE
+from random_address._dataset import data_source
+
+# A line straight out of the file, before anything has established that it is
+# shaped like an Address. Typing these as Address would assume the very thing
+# these tests exist to check, so they stay raw.
+Record: TypeAlias = dict[str, Any]
 
 ADDRESS_FIELDS = {"address1", "address2", "city", "state", "postal_code", "coordinates"}
 
@@ -39,16 +44,15 @@ MIN_LNG, MAX_LNG = -180.0, -64.0
 
 @pytest.fixture(scope="session")
 def lines() -> list[str]:
-    source = resources.files("random_address").joinpath(*DATA_FILE)
-    return source.read_text(encoding="utf-8").splitlines()
+    return data_source().read_text(encoding="utf-8").splitlines()
 
 
 @pytest.fixture(scope="session")
-def records(lines: list[str]) -> list[dict]:
+def records(lines: list[str]) -> list[Record]:
     return [json.loads(line) for line in lines]
 
 
-def sort_key(record: dict) -> tuple[str, ...]:
+def sort_key(record: Record) -> tuple[str, ...]:
     # Missing fields would raise KeyError here and mask the field-presence test,
     # which reports the real problem far more clearly.
     return tuple(
@@ -75,37 +79,37 @@ class TestLayout:
                 f"re-run data/add_addresses.py rather than editing by hand"
             )
 
-    def test_records_are_sorted(self, records: list[dict]) -> None:
+    def test_records_are_sorted(self, records: list[Record]) -> None:
         assert sorted(records, key=sort_key) == records, (
             "dataset is out of order; re-run data/add_addresses.py, which sorts on write"
         )
 
 
 class TestRecords:
-    def test_every_record_has_exactly_the_expected_fields(self, records: list[dict]) -> None:
+    def test_every_record_has_exactly_the_expected_fields(self, records: list[Record]) -> None:
         for record in records:
             assert set(record) == ADDRESS_FIELDS, record
 
     @pytest.mark.parametrize("field", ["address1", "city", "state", "postal_code"])
-    def test_required_fields_are_non_empty_strings(self, records: list[dict], field: str) -> None:
+    def test_required_fields_are_non_empty_strings(self, records: list[Record], field: str) -> None:
         for record in records:
             value = record[field]
             assert isinstance(value, str) and value.strip(), f"{field} is empty in {record}"
 
-    def test_address2_is_a_string_and_may_be_blank(self, records: list[dict]) -> None:
+    def test_address2_is_a_string_and_may_be_blank(self, records: list[Record]) -> None:
         # A unit or apartment number is genuinely optional.
         for record in records:
             assert isinstance(record["address2"], str)
 
-    def test_state_is_a_two_letter_code(self, records: list[dict]) -> None:
+    def test_state_is_a_two_letter_code(self, records: list[Record]) -> None:
         for record in records:
             assert STATE.match(record["state"]), record
 
-    def test_postal_code_is_five_digits(self, records: list[dict]) -> None:
+    def test_postal_code_is_five_digits(self, records: list[Record]) -> None:
         for record in records:
             assert POSTAL_CODE.match(record["postal_code"]), record
 
-    def test_coordinates_are_finite_and_inside_the_us(self, records: list[dict]) -> None:
+    def test_coordinates_are_finite_and_inside_the_us(self, records: list[Record]) -> None:
         for record in records:
             coordinates = record["coordinates"]
             assert set(coordinates) == {"lat", "lng"}, record
@@ -116,7 +120,7 @@ class TestRecords:
             assert MIN_LAT <= lat <= MAX_LAT, record
             assert MIN_LNG <= lng <= MAX_LNG, record
 
-    def test_street_abbreviations_are_spelled_out(self, records: list[dict]) -> None:
+    def test_street_abbreviations_are_spelled_out(self, records: list[Record]) -> None:
         # 50 Arlington records shipped as "1172 N VERMONT ST" because the old
         # ingest script did no normalization. Only the final token is checked:
         # DC really does have a street named S ("1200 S Street"), and "4221 U.S. 5"
@@ -134,7 +138,7 @@ class TestRecords:
             f"for example {offenders[:3]}"
         )
 
-    def test_normalizing_the_dataset_again_changes_nothing(self, records: list[dict]) -> None:
+    def test_normalizing_the_dataset_again_changes_nothing(self, records: list[Record]) -> None:
         """The ingest normalizer must be a no-op on data it has already produced.
 
         This is the strongest guard on the pair: it catches both an un-normalized
@@ -159,7 +163,7 @@ class TestRecords:
             f"Either the record is not normalized, or normalize_street corrupts it."
         )
 
-    def test_there_are_no_duplicate_addresses(self, records: list[dict]) -> None:
+    def test_there_are_no_duplicate_addresses(self, records: list[Record]) -> None:
         counts = Counter(
             (
                 record["state"],


### PR DESCRIPTION
The package ships py.typed, which promises downstream users working type hints, but nothing ran mypy. Enforce it in CI, strict, over src/, tests/ and data/. Most of the 54 errors that surfaced were missing annotations. Five were not.

_dataset.load_addresses passed both path components to Traversable.joinpath, which only accepts several children from 3.11 on. A normal install gets a pathlib.Path back from resources.files(), whose joinpath has always been variadic, so this worked and the 3.10 CI job stayed green; a zip-imported package gets a real Traversable and would not. The dataset integrity tests reached for the file with the same broken call, because they duplicated the walk. Both now go through _dataset.data_source(), so the traversal is written once.

Naming Traversable to do that meant importing it, and importlib.abc is deprecated and removed in 3.14 -- a version this project tests against. The DeprecationWarning sat unread in the pytest output, predicting a failure of the 3.14 job. Import from importlib.resources.abc from 3.11 on, and turn warnings into errors so the next one cannot hide: the package has no runtime dependencies, so a warning during a test run is always the standard library deprecating something out from under us.

TestConvert indexed the address _convert returns without checking it for None. _convert returns None and a reason when it rejects a record, so a test whose record was unexpectedly rejected died with "'NoneType' object is not subscriptable" while the reason it was rejected sat unread in the other half of the tuple. These now assert the address is not None and pass the reason as the assertion message, so a rejection reports why.

_valid_coordinates returned bool, so nothing established that the caller could index what it had just validated. It returns a TypeGuard now.

The dataset fixture was typed Callable[..., None], whose ellipsis accepts any arguments at all; a test installing something that was not an Address type-checked happily. It is a Protocol with a real signature now.

The release guard compared the tag against pyproject.toml only. __version__ is a second, separate declaration, and it is what `random-address --version` reports, so bumping pyproject alone would publish a correct wheel that misreports itself on the command line. Check the tag against both.