### PR TITLE
Add count(), two new states, and stronger dataset guards for 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.1.1] - 2026-08-23
+
+An additive release. Everything from 2.1.0 keeps working unchanged; there is one new function, a
+hundred new addresses, and a tighter set of guards on the data.
+
+### Added
+- `count()` returns how many addresses match, without drawing one. It takes the same `state`, `city` and `postal_code` filters as `real_random_address()`, combining and normalizing them identically, and it is the way to size a fixture before asking for it: `real_random_addresses(n, unique=True)` raises when `n` exceeds the number of matches, and `count()` is how you learn `n`. Where the lookup functions raise `NoMatchingAddressError`, `count()` returns `0` — asking how many addresses there are is a question that a zero answers. It reuses the same internal filtering the lookups use, so the two can never disagree about what a filter means.
+- Texas and Oregon, bringing the dataset to 3,400 addresses across 20 states. 50 each, spread across five Texas cities (Houston, San Antonio, Dallas, Austin, Fort Worth) over 32 postal codes, and six in the Portland metro (Portland, Beaverton, Hillsboro, Gresham, Tigard, Lake Oswego) over 20. Both sources are public domain and neither requires attribution: Texas from TNRIS StratMap Address Points (CC0), Oregon from the City of Portland (PDDL 1.0). They are credited under Attribution all the same.
+- `ROADMAP.md`, recording work that has been considered and deliberately deferred, with the reason. Requests for particular cities still belong in GitHub Issues; this is for decisions that would otherwise be lost in a pull request comment.
+- Dataset integrity tests now check that a state code is a state that exists, not merely two capital letters — `ZZ` passed the old shape check — and that `coordinates` is really a dict whose values lie within the global latitude and longitude limits as well as inside the US box.
+- Tests that pin `count()` against the existing introspection functions: `count(state=X)` must equal `state_counts()[X]` for every state, and likewise for every city and postal code. Nothing hardcodes 3,400, so growing the dataset does not break the suite.
+
+### Changed
+- The canonical duplicate key now includes `city` and collapses runs of whitespace as well as case. The two halves pull in opposite directions. Collapsing whitespace merges keys: `1  Main  Street` and `1 Main Street` were treated as distinct and now share one. Including `city` splits them: two records sharing a street, ZIP and state but sitting in different cities were collapsed into one, and are now kept apart. `data/add_addresses.py` and the dataset integrity test now derive the key the same way, so what the ingest script skips is exactly what the dataset refuses to ship. No existing record changed: the stronger key finds no duplicates in the shipped data.
+- `data/add_addresses.py` accounts for every record it reads. A run reported rejections by reason but never said how many records it had looked at, so `47083 bad postal code` gave no sense of whether that was the whole file or a rounding error. It now prints how many were read, passed validation, were skipped as duplicates, were rejected, were sampled, and were added, along with the dataset size before and after. Duplicates are counted separately rather than being folded anonymously into the rejection tally.
+
+### Fixed
+- The README's `state_counts()` example claimed 332 California addresses. There are 331, and there were 331 when it was written.
+
 ## [2.1.0] - 2026-07-12
 
 A dataset release. The library's API is unchanged, but the data it ships has been cleaned up and
@@ -114,6 +133,7 @@ the old function names to the new ones.
 ### Added
 - First public preview release.
 
+[2.1.1]: https://github.com/neosergio/random-address/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/neosergio/random-address/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/neosergio/random-address/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/neosergio/random-address/compare/v1.2.1...v1.3.0

--- a/README.md
+++ b/README.md
@@ -81,13 +81,60 @@ more addresses than the filters can supply.
 >>> random_address.list_states()
 ['AK', 'AL', 'AR', 'AZ', 'CA', ...]
 >>> random_address.state_counts()
-{'AK': 174, 'AL': 193, 'AR': 190, 'AZ': 199, 'CA': 332, ...}
+{'AK': 174, 'AL': 193, 'AR': 190, 'AZ': 199, 'CA': 331, ...}
 >>> random_address.summary()
-{'total_addresses': 3300, 'unique_states': 18, 'unique_cities': 426, 'unique_postal_codes': 694}
+{'total_addresses': 3400, 'unique_states': 20, 'unique_cities': 437, 'unique_postal_codes': 746}
 ```
 
 `list_cities()`, `list_postal_codes()`, `city_counts()` and `postal_code_counts()` work the
 same way.
+
+### Counting matches
+
+`count()` answers how many addresses match, without drawing one. It takes the same `state`,
+`city` and `postal_code` filters as `real_random_address()`, and they combine the same way.
+
+```python
+>>> import random_address
+
+>>> random_address.count()
+3400
+>>> random_address.count(state='CA')
+331
+>>> random_address.count(city='Arlington')
+52
+>>> random_address.count(postal_code='22204')
+13
+>>> random_address.count(state='TX', city='Houston')
+10
+```
+
+Filters combine, which is how you tell two places of the same name apart. Fifty of those
+Arlingtons are in Virginia and two are in Massachusetts:
+
+```python
+>>> random_address.count(state='VA', city='Arlington')
+50
+>>> random_address.count(state='MA', city='Arlington')
+2
+```
+
+Where the lookup functions raise `NoMatchingAddressError`, `count()` returns `0` — asking how
+many there are is a question that a zero answers:
+
+```python
+>>> random_address.count(state='ZZ')
+0
+```
+
+It is the honest way to size a fixture before asking for one, since
+`real_random_addresses(n, unique=True)` raises when `n` exceeds the number of matches:
+
+```python
+>>> total = random_address.count(state='OR')
+>>> len(random_address.real_random_addresses(total, state='OR'))
+50
+```
 
 ## Command line
 
@@ -105,6 +152,7 @@ $ random-address summary
 
 - `real_random_address(*, state=None, city=None, postal_code=None, seed=None)`: one address, optionally filtered.
 - `real_random_addresses(count=1, *, state=None, city=None, postal_code=None, seed=None, unique=True)`: several addresses.
+- `count(*, state=None, city=None, postal_code=None)`: how many addresses match, `0` if none do.
 - `list_states()`, `list_cities()`, `list_postal_codes()`: the values present in the dataset.
 - `state_counts()`, `city_counts()`, `postal_code_counts()`: how many addresses each value has.
 - `summary()`: dataset-wide totals.
@@ -242,6 +290,8 @@ All data collected from the [OpenAddresses](https://openaddresses.io/) project, 
 * City of Honolulu (HI)
 * Arlington County (VA)
 * Durham County (NC)
+* City of Portland (OR)
+* Texas Natural Resources Information System, StratMap Address Points (TX)
 
 ## Requesting New Location Data
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,88 @@
+# Roadmap
+
+Work that has been considered and deliberately deferred, with the reason. This is not a promise of
+dates or of delivery; it is a record so that the same ground is not re-covered from scratch, and so
+that a deferred decision is visible rather than lost in a pull request comment.
+
+Requests for specific cities, states or postal codes do not belong here. Those go to
+[GitHub Issues](https://github.com/neosergio/random-address/issues), which is the workflow the README
+describes, and they are added gradually to keep the package small.
+
+## A `count` subcommand for the CLI
+
+`count()` landed in 2.1.1 as a Python function only. The CLI already has a `summary` subcommand, so
+`random-address count --state CA` is the obvious companion, and the argument parsing for `--state`,
+`--city` and `--postal-code` already exists on the `get` subcommand.
+
+Deferred because 2.1.1 was a patch release. Growing the command line surface changes what the tool
+looks like to somebody reading `--help`, which is a minor-release decision rather than a patch one.
+
+## Broader geographic coverage
+
+The dataset holds 20 states after 2.1.1. Thirty-one are still unrepresented: DE HI IA ID IL IN KS LA
+ME MI MN MO MS MT ND NE NH NJ NM NV NY OH PA RI SC SD UT WA WI WV WY.
+
+This is gated on licensing, not on effort. Every address here is public domain, which is the one
+promise the library makes, and OpenAddresses is the ceiling on what can be added. Two obstacles come
+up repeatedly:
+
+- **Attribution-required sources are unusable.** Utah's statewide source is otherwise ideal — 1.5
+  million rows, complete postal codes — but it is CC BY 4.0 with `attribution: true`. Boise is the
+  same. Share-alike sources (ODbL, and Portland Metro's RLIS) are out for the same reason.
+- **Most current sources declare no license at all.** OpenAddresses' schema-2 sources frequently
+  carry no `license` block, which reports as `false` in the job metadata. That includes several
+  large, high-quality candidates: `us/ny/statewide`, `us/il/cook`, `us/nj/statewide`,
+  `us/pa/allegheny`, `us/mn/hennepin`, `us/oh/city_of_columbus`, `us/de/statewide`,
+  `us/nd/statewide`, `us/ks/statewide`. Absence of a license is *unknown*, not *public domain*, so
+  using them means checking each upstream publisher's terms by hand first.
+
+Texas was imported from `us/tx/statewide` (CC0) despite being 337 MB compressed and roughly 2.5 GB
+uncompressed. `_read_features` reads a source fully into memory, so that file had to be narrowed to
+the target cities by streaming before the ingest script could touch it. Any future statewide source
+of that size needs the same treatment, or `_read_features` needs to stream.
+
+## Unifying the two version declarations
+
+The version is written twice, in `pyproject.toml` and in `src/random_address/__init__.py`. The
+duplication is intentional and guarded: `publish.yml` fails a release unless the git tag, the
+pyproject version and `__version__` all agree.
+
+Collapsing it — setuptools `dynamic = ["version"]` reading `random_address.__version__` — means
+rewriting that guard, since two of the three values it compares would become the same value and the
+check would weaken. Worth doing, but not inside a patch release.
+
+## Attribution lists Hawaii, but there are no Hawaii addresses
+
+The README credits *City of Honolulu (HI)* under Attribution, and the dataset contains no HI records.
+Most likely a leftover: 2.1.0 removed twenty records that had no city, and earlier releases removed
+others.
+
+Left alone deliberately. Editing an attribution list is a statement about provenance, and it should
+be corrected by someone who knows whether those records were removed or never shipped — not silently,
+as a side effect of an unrelated release.
+
+## The leading-directional rule misfires on suffix-shaped street names
+
+`normalize_street` leaves a leading directional unexpanded when the next token is a word that also
+appears as a spelled-out street suffix. `SE MEADOW CT` normalized to `Se Meadow Court` rather than
+`Southeast Meadow Court`, because `Meadow` is the expansion of `MDW`; `SW GARDEN PL` failed the same
+way through `GDN`. Two Oregon records shipped like that in 2.1.1 and were corrected by hand. The next
+import from a source that abbreviates directionals will reintroduce it.
+
+The guard exists for a real reason — Washington DC has streets named after letters, so `S ST NW` must
+stay `S Street Northwest` — and it is not safe to simply drop. Replacing the word test with a
+position test (`suffix_at != 1`) looks right and is wrong: on the already-normalized `S Street
+Northwest` the trailing `Northwest` is no longer recognized as a directional, so the suffix position
+shifts and the rule corrupts three DC records into `South Street Northwest`. Any fix has to treat
+spelled-out directionals as directionals when locating the suffix, and has to be checked against both
+the raw and the already-normalized form of the same address.
+
+## A stale comment in the ingest script
+
+`ROUTE_PREFIXES` and the docstring of `_preserved` in `data/add_addresses.py` both refer to a
+`_is_dotted_initialism` helper that does not exist. Dotted forms such as `U.S. 5` are actually handled
+by the `character in ".&"` check inside `_preserved`.
+
+Purely cosmetic, and it touches the normalizer, which is the single most delicate part of the ingest
+path — the 2.1.0 changelog lists six separate street names it had corrupted. A comment fix is not
+worth re-opening that file during a release focused on something else.

--- a/data/add_addresses.py
+++ b/data/add_addresses.py
@@ -131,21 +131,25 @@ def main(argv: list[str] | None = None) -> int:
     seen = {_key(address) for address in existing}
     rejected: Counter[str] = Counter()
     candidates: list[dict[str, Any]] = []
+    read = 0
+    duplicates = 0
 
     for feature in _read_features(args.source):
+        read += 1
         address, reason = _convert(feature, args)
         if address is None:
             rejected[reason] += 1
             continue
         key = _key(address)
         if key in seen:
-            rejected["duplicate"] += 1
+            duplicates += 1
             continue
         seen.add(key)
         candidates.append(address)
 
     if not candidates:
         print("No usable addresses found.", file=sys.stderr)
+        _report_summary(read, len(candidates), duplicates, rejected, 0, len(existing))
         _report(rejected)
         _explain_wholesale_rejection(rejected)
         return 1
@@ -160,11 +164,26 @@ def main(argv: list[str] | None = None) -> int:
         selected = generator.sample(candidates, count)
 
     if not selected:
+        # Reachable only through --cities: there were usable candidates, just
+        # none in any of the cities asked for. Reporting the tally here too says
+        # how much the source held, which is what tells a bad --cities apart
+        # from a bad source.
         print("No usable addresses found.", file=sys.stderr)
+        _report_summary(read, len(candidates), duplicates, rejected, 0, len(existing))
         return 1
 
     print(f"Selected {len(selected)} addresses for {args.state}")
     _report_by_city(selected)
+    print()
+    _report_summary(
+        read,
+        len(candidates),
+        duplicates,
+        rejected,
+        len(selected),
+        len(existing),
+        dry_run=args.dry_run,
+    )
     _report(rejected)
 
     if args.dry_run:
@@ -463,19 +482,22 @@ def _valid_coordinates(coordinates: Any) -> TypeGuard[Sequence[float]]:
     return MIN_LAT <= lat <= MAX_LAT and MIN_LNG <= lng <= MAX_LNG
 
 
-def _key(address: dict[str, Any]) -> tuple[str, str, str, str]:
+def _key(address: dict[str, Any]) -> tuple[str, ...]:
     """Identify an address for duplicate detection.
 
     address2 is part of the key: two apartments in one building share a street
     address but are different addresses. Leaving it out collapsed them, and in
     the Durham source that would have discarded 5,057 distinct units while
     reporting them as duplicates.
+
+    City is in the key and whitespace is collapsed as well as case, so that a
+    source publishing "1  MAIN  ST" cannot slip past a dataset already holding
+    "1 Main Street". tests/test_dataset.py mirrors this exactly: what is skipped
+    here is what the dataset refuses to ship.
     """
-    return (
-        address["state"].upper(),
-        address["postal_code"],
-        address["address1"].casefold(),
-        address["address2"].casefold(),
+    return tuple(
+        " ".join(str(address.get(field, "")).split()).casefold()
+        for field in ("state", "city", "postal_code", "address1", "address2")
     )
 
 
@@ -617,6 +639,48 @@ def _explain_wholesale_rejection(rejected: Counter[str]) -> None:
             "no city.\nPass --city to supply one for the whole file.",
             file=sys.stderr,
         )
+
+
+def _report_summary(
+    read: int,
+    valid: int,
+    duplicates: int,
+    rejected: Counter[str],
+    selected: int,
+    existing: int,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Account for every record the source offered.
+
+    A run reports rejections by reason, but never said how many records it had
+    looked at, so "Rejected: 119901 bad postal code" gave no sense of whether
+    that was the whole file or a rounding error.
+
+    Valid and Rejected account between them for every record read. Duplicates is
+    the part of Valid that is already present, in the dataset or earlier in the
+    same source, and so is not available to sample.
+
+    The last line states what happens to the dataset, so on a dry run it has to
+    say what would happen. Printing "Added" directly above "Dry run, nothing
+    written" claims a write that did not occur.
+    """
+    lines = [
+        ("Read", read, "records in the source"),
+        ("Valid", valid + duplicates, "passed validation"),
+        ("Duplicates", duplicates, "already in the dataset, or repeated in the source"),
+        ("Rejected", sum(rejected.values()), "failed validation"),
+        ("Selected", selected, "sampled from the valid records"),
+    ]
+    if selected:
+        label = "Would add" if dry_run else "Added"
+        lines.append((label, selected, f"dataset {existing} -> {existing + selected}"))
+
+    width = max(len(label) for label, _, _ in lines)
+    total = max(total for _, total, _ in lines)
+    digits = len(f"{total:,}")
+    for label, count, note in lines:
+        print(f"{label:<{width}}  {count:>{digits},}  {note}")
 
 
 def _report(rejected: Counter[str]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "random-address"
-version = "2.1.0"
+version = "2.1.1"
 description = "Retrieve real random US addresses, with coordinates, for tests and fixtures"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/random_address/__init__.py
+++ b/src/random_address/__init__.py
@@ -8,6 +8,7 @@ that source, so it resolves to a real point on the map without a geocoding call.
 from .core import (
     NoMatchingAddressError,
     city_counts,
+    count,
     list_cities,
     list_postal_codes,
     list_states,
@@ -26,6 +27,7 @@ __all__ = [
     "Seed",
     "Summary",
     "city_counts",
+    "count",
     "list_cities",
     "list_postal_codes",
     "list_states",
@@ -36,4 +38,4 @@ __all__ = [
     "summary",
 ]
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/src/random_address/core.py
+++ b/src/random_address/core.py
@@ -155,6 +155,48 @@ def summary() -> Summary:
     }
 
 
+def count(
+    *,
+    state: str | None = None,
+    city: str | None = None,
+    postal_code: str | None = None,
+) -> int:
+    """Count the addresses matching the given filters, without drawing one.
+
+    Filters combine and are matched exactly as they are by
+    :func:`real_random_address`, so state codes and city names are
+    case-insensitive and surrounding whitespace is ignored. Postal codes are
+    matched exactly.
+
+    Unlike the lookup functions, this returns ``0`` rather than raising when
+    nothing matches: asking how many addresses there are is a question that a
+    zero answers.
+
+    Args:
+        state: Two-letter state code, for example ``"CA"``. Counts every state
+            when omitted.
+        city: City name, for example ``"Newark"``. Counts every city when
+            omitted.
+        postal_code: Postal code, for example ``"94560"``. Counts every postal
+            code when omitted.
+
+    Returns:
+        How many addresses match, or the size of the whole dataset when no
+        filter is given.
+
+    Example:
+        >>> count()
+        3400
+        >>> count(state="CA")
+        331
+        >>> count(state="VA", city="Arlington")
+        50
+        >>> count(state="ZZ")
+        0
+    """
+    return len(_pool(state=state, city=city, postal_code=postal_code))
+
+
 def _pool(
     *,
     state: str | None,

--- a/src/random_address/data/addresses-us.jsonl
+++ b/src/random_address/data/addresses-us.jsonl
@@ -2896,6 +2896,56 @@
 {"address1": "10725 Sunset Boulevard", "address2": "", "city": "Spencer", "state": "OK", "postal_code": "73084", "coordinates": {"lat": 35.564321, "lng": -97.339423}}
 {"address1": "2455 Manchester Drive", "address2": "", "city": "The Village", "state": "OK", "postal_code": "73120", "coordinates": {"lat": 35.576392, "lng": -97.55644629999999}}
 {"address1": "4807 North Grove Avenue", "address2": "", "city": "Warr Acres", "state": "OK", "postal_code": "73122", "coordinates": {"lat": 35.5203601, "lng": -97.6147122}}
+{"address1": "2640 Southwest 204th Avenue", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97003", "coordinates": {"lat": 45.5007486, "lng": -122.8867664}}
+{"address1": "11410 Southwest Fairfield Street", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97005", "coordinates": {"lat": 45.4967995, "lng": -122.7942108}}
+{"address1": "3720 Southwest 141st Avenue", "address2": "207", "city": "Beaverton", "state": "OR", "postal_code": "97005", "coordinates": {"lat": 45.4924745, "lng": -122.8211816}}
+{"address1": "17404 Northwest Autumn Ridge Drive", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97006", "coordinates": {"lat": 45.5276344, "lng": -122.8557824}}
+{"address1": "2306 Northwest Schmidt Way", "address2": "1", "city": "Beaverton", "state": "OR", "postal_code": "97006", "coordinates": {"lat": 45.5361547, "lng": -122.8488301}}
+{"address1": "12900 Southwest Zigzag Lane", "address2": "102", "city": "Beaverton", "state": "OR", "postal_code": "97007", "coordinates": {"lat": 45.4262902, "lng": -122.8709344}}
+{"address1": "15600 Southwest Talus Way", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97007", "coordinates": {"lat": 45.4482687, "lng": -122.8369686}}
+{"address1": "17574 Southwest Sarala Street", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97007", "coordinates": {"lat": 45.4630685, "lng": -122.8581482}}
+{"address1": "17667 Southwest Cody Lane", "address2": "", "city": "Beaverton", "state": "OR", "postal_code": "97007", "coordinates": {"lat": 45.4713271, "lng": -122.8587812}}
+{"address1": "1545 Southeast 223rd Avenue", "address2": "276", "city": "Gresham", "state": "OR", "postal_code": "97030", "coordinates": {"lat": 45.5113596, "lng": -122.4345603}}
+{"address1": "1911 Northwest 17th Street", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97030", "coordinates": {"lat": 45.5096918, "lng": -122.4512811}}
+{"address1": "3523 Northeast 15th Street", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97030", "coordinates": {"lat": 45.5079589, "lng": -122.3972187}}
+{"address1": "2371 Southeast Meadow Court", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97080", "coordinates": {"lat": 45.480305, "lng": -122.4326056}}
+{"address1": "2437 Southwest 30th Court", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97080", "coordinates": {"lat": 45.4759615, "lng": -122.4583401}}
+{"address1": "35321 Southeast Dodge Park Boulevard", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97080", "coordinates": {"lat": 45.4702034, "lng": -122.2967484}}
+{"address1": "4456 Southeast Antelope Hills Place", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97080", "coordinates": {"lat": 45.466286, "lng": -122.4355443}}
+{"address1": "755 Southeast 18th Lane", "address2": "", "city": "Gresham", "state": "OR", "postal_code": "97080", "coordinates": {"lat": 45.4840963, "lng": -122.4238046}}
+{"address1": "716 Northeast Adwick Drive", "address2": "", "city": "Hillsboro", "state": "OR", "postal_code": "97006", "coordinates": {"lat": 45.5250009, "lng": -122.8879368}}
+{"address1": "2550 Southeast Century Boulevard", "address2": "109", "city": "Hillsboro", "state": "OR", "postal_code": "97123", "coordinates": {"lat": 45.501059, "lng": -122.9164861}}
+{"address1": "269 Southeast 29th Avenue", "address2": "", "city": "Hillsboro", "state": "OR", "postal_code": "97123", "coordinates": {"lat": 45.519468, "lng": -122.9538396}}
+{"address1": "869 Southeast 67th Avenue", "address2": "", "city": "Hillsboro", "state": "OR", "postal_code": "97123", "coordinates": {"lat": 45.5129, "lng": -122.9114235}}
+{"address1": "2571 Northeast Overlook Drive", "address2": "623", "city": "Hillsboro", "state": "OR", "postal_code": "97124", "coordinates": {"lat": 45.5383175, "lng": -122.8846909}}
+{"address1": "3069 Northeast Overlook Drive", "address2": "538", "city": "Hillsboro", "state": "OR", "postal_code": "97124", "coordinates": {"lat": 45.5437291, "lng": -122.8833103}}
+{"address1": "784 Northeast Caden Avenue", "address2": "", "city": "Hillsboro", "state": "OR", "postal_code": "97124", "coordinates": {"lat": 45.5285475, "lng": -122.918928}}
+{"address1": "919 Northeast 3rd Avenue", "address2": "", "city": "Hillsboro", "state": "OR", "postal_code": "97124", "coordinates": {"lat": 45.5310788, "lng": -122.98697}}
+{"address1": "17632 Woodhurst Place", "address2": "", "city": "Lake Oswego", "state": "OR", "postal_code": "97034", "coordinates": {"lat": 45.3971013, "lng": -122.6572222}}
+{"address1": "12375 Mt Jefferson Terrace", "address2": "4F", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4299114, "lng": -122.7148068}}
+{"address1": "15000 Davis Lane", "address2": "31", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4180338, "lng": -122.7142795}}
+{"address1": "3 Centerpointe Drive", "address2": "110", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4236648, "lng": -122.7406444}}
+{"address1": "351 Cervantes", "address2": "", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4348258, "lng": -122.7262913}}
+{"address1": "4000 Carman Drive", "address2": "C47", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4192739, "lng": -122.7204537}}
+{"address1": "5950 Harrington Avenue", "address2": "", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.4074249, "lng": -122.7382727}}
+{"address1": "6145 Southwest McEwan Road", "address2": "", "city": "Lake Oswego", "state": "OR", "postal_code": "97035", "coordinates": {"lat": 45.3912771, "lng": -122.7390662}}
+{"address1": "1300 Southwest Park Avenue", "address2": "302", "city": "Portland", "state": "OR", "postal_code": "97201", "coordinates": {"lat": 45.5152336, "lng": -122.6823057}}
+{"address1": "3161 Southeast 81st Avenue", "address2": "", "city": "Portland", "state": "OR", "postal_code": "97206", "coordinates": {"lat": 45.4993425, "lng": -122.5800668}}
+{"address1": "745 Northwest Hoyt Street", "address2": "3963", "city": "Portland", "state": "OR", "postal_code": "97209", "coordinates": {"lat": 45.5275579, "lng": -122.6790792}}
+{"address1": "1831 Southeast Hawthorne Boulevard", "address2": "303", "city": "Portland", "state": "OR", "postal_code": "97214", "coordinates": {"lat": 45.5124068, "lng": -122.6467951}}
+{"address1": "6710 North Michigan Avenue", "address2": "", "city": "Portland", "state": "OR", "postal_code": "97217", "coordinates": {"lat": 45.5712963, "lng": -122.676538}}
+{"address1": "7000 Southwest Vermont Street", "address2": "1208", "city": "Portland", "state": "OR", "postal_code": "97223", "coordinates": {"lat": 45.4757314, "lng": -122.7486881}}
+{"address1": "3381 Northeast 162nd Avenue", "address2": "", "city": "Portland", "state": "OR", "postal_code": "97230", "coordinates": {"lat": 45.5475628, "lng": -122.497508}}
+{"address1": "2055 Northeast Glisan Street", "address2": "", "city": "Portland", "state": "OR", "postal_code": "97232", "coordinates": {"lat": 45.5269496, "lng": -122.6451646}}
+{"address1": "5332 Southeast 137th Avenue", "address2": "", "city": "Portland", "state": "OR", "postal_code": "97236", "coordinates": {"lat": 45.4842648, "lng": -122.521986}}
+{"address1": "12242 Southwest Garden Place", "address2": "", "city": "Tigard", "state": "OR", "postal_code": "97223", "coordinates": {"lat": 45.4318793, "lng": -122.7634304}}
+{"address1": "13815 Southwest Pacific Highway", "address2": "30", "city": "Tigard", "state": "OR", "postal_code": "97223", "coordinates": {"lat": 45.4202065, "lng": -122.7864027}}
+{"address1": "6950 Southwest Hampton Street", "address2": "203", "city": "Tigard", "state": "OR", "postal_code": "97223", "coordinates": {"lat": 45.4270673, "lng": -122.7484834}}
+{"address1": "9495 Southwest Shady Place", "address2": "", "city": "Tigard", "state": "OR", "postal_code": "97223", "coordinates": {"lat": 45.4513642, "lng": -122.7517188}}
+{"address1": "11041 Southwest Summerfield Drive", "address2": "1", "city": "Tigard", "state": "OR", "postal_code": "97224", "coordinates": {"lat": 45.4070509, "lng": -122.7901116}}
+{"address1": "15228 Southwest Deepbrook Lane", "address2": "", "city": "Tigard", "state": "OR", "postal_code": "97224", "coordinates": {"lat": 45.4073531, "lng": -122.8333393}}
+{"address1": "15305 Southwest Missouri Avenue", "address2": "", "city": "Tigard", "state": "OR", "postal_code": "97224", "coordinates": {"lat": 45.4089644, "lng": -122.8356585}}
+{"address1": "16697 Southwest 108th Avenue", "address2": "", "city": "Tigard", "state": "OR", "postal_code": "97224", "coordinates": {"lat": 45.3993339, "lng": -122.7881626}}
 {"address1": "4696 Bull Run Road", "address2": "", "city": "Ashland City", "state": "TN", "postal_code": "37015", "coordinates": {"lat": 36.241285, "lng": -86.940741}}
 {"address1": "1021 Heathfield Circle", "address2": "", "city": "Brentwood", "state": "TN", "postal_code": "37027", "coordinates": {"lat": 36.024992, "lng": -86.75297200000001}}
 {"address1": "123 Villa View Court", "address2": "", "city": "Brentwood", "state": "TN", "postal_code": "37027", "coordinates": {"lat": 36.0355599, "lng": -86.7806023}}
@@ -3090,6 +3140,56 @@
 {"address1": "880 General George Patton Road", "address2": "", "city": "Nashville", "state": "TN", "postal_code": "37221", "coordinates": {"lat": 36.066698, "lng": -86.945662}}
 {"address1": "9360 Hester Beasley Road", "address2": "", "city": "Nashville", "state": "TN", "postal_code": "37221", "coordinates": {"lat": 36.018232, "lng": -87.025104}}
 {"address1": "8673 Burkitt Place Drive", "address2": "", "city": "Nolensville", "state": "TN", "postal_code": "37135", "coordinates": {"lat": 35.987552, "lng": -86.6763689}}
+{"address1": "6404 Hudson Street", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78721", "coordinates": {"lat": 30.2705801, "lng": -97.6724402}}
+{"address1": "12603 Beaconsdale Circle", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78727", "coordinates": {"lat": 30.4255693, "lng": -97.7135246}}
+{"address1": "2100 Lamplight Village Circle", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78727", "coordinates": {"lat": 30.4170106, "lng": -97.6956884}}
+{"address1": "3830 Williamsburg Circle", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78731", "coordinates": {"lat": 30.3664091, "lng": -97.7550776}}
+{"address1": "4107 Edwards Mountain Drive", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78731", "coordinates": {"lat": 30.3495873, "lng": -97.7693124}}
+{"address1": "4809 West Park Drive", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78731", "coordinates": {"lat": 30.3256415, "lng": -97.7529277}}
+{"address1": "1313 1/2 North Weston Lane", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78733", "coordinates": {"lat": 30.3280833, "lng": -97.8448088}}
+{"address1": "5701 Hero Drive", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78735", "coordinates": {"lat": 30.2515309, "lng": -97.8453943}}
+{"address1": "7801 1/2 Metropolis Drive", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78744", "coordinates": {"lat": 30.2071632, "lng": -97.6934244}}
+{"address1": "2102 1/2 Rue De St Germaine", "address2": "", "city": "Austin", "state": "TX", "postal_code": "78746", "coordinates": {"lat": 30.3063388, "lng": -97.7845091}}
+{"address1": "2616 Calvin Street", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75204", "coordinates": {"lat": 32.8108765, "lng": -96.787948}}
+{"address1": "4336 Wyoming Street", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75211", "coordinates": {"lat": 32.713687, "lng": -96.8898935}}
+{"address1": "1646 East Elmore Avenue", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75216", "coordinates": {"lat": 32.7175938, "lng": -96.7980817}}
+{"address1": "2502 Lea Crest Drive", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75216", "coordinates": {"lat": 32.7100274, "lng": -96.789342}}
+{"address1": "2616 Bowling Green Avenue", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75216", "coordinates": {"lat": 32.7162642, "lng": -96.7970474}}
+{"address1": "3130 South Ewing Avenue", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75216", "coordinates": {"lat": 32.706335, "lng": -96.810595}}
+{"address1": "4124 Huckleberry Circle", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75216", "coordinates": {"lat": 32.6936872, "lng": -96.8219871}}
+{"address1": "306 Guthrie Street", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75224", "coordinates": {"lat": 32.7182922, "lng": -96.826809}}
+{"address1": "5739 Russcrest Drive", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75227", "coordinates": {"lat": 32.7823263, "lng": -96.7037142}}
+{"address1": "3919 Juneau Avenue", "address2": "", "city": "Dallas", "state": "TX", "postal_code": "75233", "coordinates": {"lat": 32.6988775, "lng": -96.8848285}}
+{"address1": "1116 Parsons Lane", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76106", "coordinates": {"lat": 32.8193666, "lng": -97.3406516}}
+{"address1": "4108 Pebblebrook Court", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76109", "coordinates": {"lat": 32.7080301, "lng": -97.3809443}}
+{"address1": "805 Fairview Street", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76111", "coordinates": {"lat": 32.7744224, "lng": -97.2953535}}
+{"address1": "1301 East Anthony Street", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76115", "coordinates": {"lat": 32.6858594, "lng": -97.3093855}}
+{"address1": "9601 North Normandale Street", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76116", "coordinates": {"lat": 32.7320564, "lng": -97.4887908}}
+{"address1": "9836 Camp Bowie West Boulevard", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76116", "coordinates": {"lat": 32.7249063, "lng": -97.4963002}}
+{"address1": "6941 Sunflower Circle North", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76120", "coordinates": {"lat": 32.7740126, "lng": -97.2085754}}
+{"address1": "12441 Kollmeyer Way", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76126", "coordinates": {"lat": 32.5878355, "lng": -97.5487039}}
+{"address1": "1673 Fagan Drive", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76131", "coordinates": {"lat": 32.8571838, "lng": -97.3395523}}
+{"address1": "5921 Sea Breeze Lane", "address2": "", "city": "Fort Worth", "state": "TX", "postal_code": "76135", "coordinates": {"lat": 32.8246786, "lng": -97.4169906}}
+{"address1": "1310 Tuam Street", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77004", "coordinates": {"lat": 29.7414328, "lng": -95.3724252}}
+{"address1": "2519 Atwood Glen Lane", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77014", "coordinates": {"lat": 29.9755326, "lng": -95.4594322}}
+{"address1": "4151 Surreydon Drive", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77014", "coordinates": {"lat": 29.9785623, "lng": -95.4854067}}
+{"address1": "8313 Hoffman Street", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77016", "coordinates": {"lat": 29.8360528, "lng": -95.3124023}}
+{"address1": "511 Kress Street", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77020", "coordinates": {"lat": 29.779713, "lng": -95.3070364}}
+{"address1": "15810 Bertasz Drive", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77049", "coordinates": {"lat": 29.8098358, "lng": -95.1514663}}
+{"address1": "2606 Grand Canyon Drive", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77067", "coordinates": {"lat": 29.9628422, "lng": -95.4731973}}
+{"address1": "2610 Teague Road", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77080", "coordinates": {"lat": 29.8191059, "lng": -95.5409886}}
+{"address1": "9917 Rolling Wagon Drive", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77080", "coordinates": {"lat": 29.8307151, "lng": -95.5400746}}
+{"address1": "10815 Radford Lane", "address2": "", "city": "Houston", "state": "TX", "postal_code": "77099", "coordinates": {"lat": 29.6512269, "lng": -95.5715633}}
+{"address1": "158 Ashley Loop", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4133887, "lng": -98.8112874}}
+{"address1": "165 Crowned Crane", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4409836, "lng": -98.8088404}}
+{"address1": "165 Spurfowl", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4405168, "lng": -98.8109229}}
+{"address1": "177 Perch Horizon", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4344754, "lng": -98.8056103}}
+{"address1": "186 Desert Bloom", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4816573, "lng": -98.8115877}}
+{"address1": "233 Antler Bend", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4208719, "lng": -98.8061126}}
+{"address1": "286 Gemsbok Gate", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4314386, "lng": -98.8104409}}
+{"address1": "3907 CR 382", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4711793, "lng": -98.8065403}}
+{"address1": "912 CR 375", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78253", "coordinates": {"lat": 29.4382337, "lng": -98.8367093}}
+{"address1": "520 Waycross Road", "address2": "", "city": "San Antonio", "state": "TX", "postal_code": "78264", "coordinates": {"lat": 29.141949, "lng": -98.5062258}}
 {"address1": "1172 North Vermont Street", "address2": "", "city": "Arlington", "state": "VA", "postal_code": "22201", "coordinates": {"lat": 38.8844138, "lng": -77.1152031}}
 {"address1": "1309 Kirkwood Road", "address2": "", "city": "Arlington", "state": "VA", "postal_code": "22201", "coordinates": {"lat": 38.8881107, "lng": -77.1004317}}
 {"address1": "1316 North Adams Court", "address2": "", "city": "Arlington", "state": "VA", "postal_code": "22201", "coordinates": {"lat": 38.8884487, "lng": -77.0874627}}

--- a/tests/test_add_addresses.py
+++ b/tests/test_add_addresses.py
@@ -9,7 +9,10 @@ code, some no city.
 from __future__ import annotations
 
 import argparse
+import json
 import random
+from collections import Counter
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -18,6 +21,8 @@ from add_addresses import (
     _balanced_sample,
     _convert,
     _key,
+    _report_summary,
+    main,
     normalize_street,
     titlecase,
 )
@@ -237,6 +242,7 @@ class TestKey:
     def address(self, **overrides: str) -> dict[str, Any]:
         base = {
             "state": "NC",
+            "city": "Durham",
             "postal_code": "27701",
             "address1": "100 Main Street",
             "address2": "",
@@ -262,6 +268,127 @@ class TestKey:
 
     def test_the_same_street_in_two_states_is_not_a_duplicate(self) -> None:
         assert _key(self.address(state="NC")) != _key(self.address(state="CA"))
+
+    def test_the_same_street_in_two_cities_is_not_a_duplicate(self) -> None:
+        # Durham and Raleigh both have a Main Street, and both are in NC.
+        assert _key(self.address(city="Durham")) != _key(self.address(city="Raleigh"))
+
+    def test_matching_ignores_runs_of_whitespace(self) -> None:
+        assert _key(self.address(address1="100  Main   Street")) == _key(self.address())
+
+
+class TestReportSummary:
+    def test_accounts_for_every_record_read(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _report_summary(
+            read=1000,
+            valid=40,
+            duplicates=10,
+            rejected=Counter({"bad postal code": 950}),
+            selected=25,
+            existing=3300,
+        )
+
+        printed = capsys.readouterr().out
+        assert "Read" in printed
+        # valid + duplicates + rejected must account for everything read, which
+        # is the whole point of printing the tally.
+        assert "1,000" in printed
+        assert "50" in printed and "10" in printed and "950" in printed
+        assert "dataset 3300 -> 3325" in printed
+
+    def test_labels_the_change_as_planned_on_a_dry_run(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # "Added 25" printed directly above "Dry run, nothing written" claims a
+        # write that did not happen.
+        _report_summary(
+            read=1000,
+            valid=40,
+            duplicates=10,
+            rejected=Counter({"bad postal code": 950}),
+            selected=25,
+            existing=3300,
+            dry_run=True,
+        )
+
+        printed = capsys.readouterr().out
+        assert "Would add" in printed
+        assert "Added" not in printed
+        # The counts themselves are unchanged by the label.
+        assert "dataset 3300 -> 3325" in printed
+
+    def test_omits_the_added_line_when_nothing_was_selected(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _report_summary(
+            read=100,
+            valid=0,
+            duplicates=0,
+            rejected=Counter({"no city": 100}),
+            selected=0,
+            existing=3300,
+        )
+
+        assert "Added" not in capsys.readouterr().out
+
+
+class TestMain:
+    """The failure paths, which are the ones that write nothing and must explain why."""
+
+    def source(self, tmp_path: Path, *cities: str) -> Path:
+        path = tmp_path / "source.geojson"
+        path.write_text(
+            "\n".join(
+                json.dumps(feature(number=str(100 + n), city=city)) for n, city in enumerate(cities)
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_reports_the_tally_when_no_requested_city_matches(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The source is fine and its records validate; they are simply not in
+        # Charlotte. Without the tally this exits on "No usable addresses found",
+        # which reads as an unusable source rather than a mistyped --cities.
+        source = self.source(tmp_path, "BOLIVIA", "BOLIVIA", "SHALLOTTE")
+
+        code = main([str(source), "--state", "NC", "--cities", "Charlotte", "--dry-run"])
+
+        captured = capsys.readouterr()
+        assert code == 1
+        assert "No usable addresses found." in captured.err
+        assert "Read" in captured.out
+        # Three records were read and all three validated; none was selected.
+        assert "3" in captured.out
+        assert "Selected" in captured.out
+        assert "Added" not in captured.out
+
+    def test_a_dry_run_does_not_claim_to_have_added_anything(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = self.source(tmp_path, "BOLIVIA", "BOLIVIA", "BOLIVIA")
+
+        code = main([str(source), "--state", "NC", "--count", "2", "--dry-run"])
+
+        printed = capsys.readouterr().out
+        assert code == 0
+        assert "Would add" in printed
+        assert "Added" not in printed
+        assert "Dry run, nothing written." in printed
+
+    def test_reports_the_tally_when_the_source_yields_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "empty.geojson"
+        source.write_text("", encoding="utf-8")
+
+        code = main([str(source), "--state", "NC", "--dry-run"])
+
+        captured = capsys.readouterr()
+        assert code == 1
+        assert "No usable addresses found." in captured.err
+        assert "Read" in captured.out
 
 
 class TestAllocate:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Callable
 from importlib import metadata
 from types import ModuleType
 
@@ -12,6 +13,7 @@ import random_address
 from random_address import (
     NoMatchingAddressError,
     city_counts,
+    count,
     list_cities,
     list_postal_codes,
     list_states,
@@ -173,7 +175,134 @@ class TestDatasetIntrospection:
         assert statistics["unique_states"] == len(list_states())
         assert statistics["unique_cities"] == len(list_cities())
         assert statistics["unique_postal_codes"] == len(list_postal_codes())
-        assert statistics["total_addresses"] > 0
+        assert statistics["total_addresses"] == count()
+
+    @pytest.mark.parametrize("counts", [state_counts, city_counts, postal_code_counts])
+    def test_every_address_is_counted_exactly_once(
+        self, counts: Callable[[], dict[str, int]]
+    ) -> None:
+        # _counts skips a falsy value, so these sums only equal the total because
+        # no bundled record has a blank state, city or postal code. The dataset
+        # integrity tests are what hold that true; if one ever regressed, the
+        # blank would vanish from the listings and this is where it would surface.
+        assert sum(counts().values()) == count()
+
+
+class TestCount:
+    """Counting is asserted against the other introspection functions.
+
+    Hardcoding 3300 here would mean every data expansion broke the suite, which
+    is exactly the friction the dataset workflow is meant to avoid. The numbers
+    these tests use come from the dataset itself; what is pinned is that count()
+    and the counts dictionaries can never disagree.
+    """
+
+    def test_with_no_filters_counts_the_whole_dataset(self) -> None:
+        assert count() == summary()["total_addresses"]
+
+    def test_agrees_with_state_counts(self) -> None:
+        assert {state: count(state=state) for state in list_states()} == state_counts()
+
+    def test_agrees_with_city_counts(self) -> None:
+        assert {city: count(city=city) for city in list_cities()} == city_counts()
+
+    def test_agrees_with_postal_code_counts(self) -> None:
+        expected = postal_code_counts()
+        assert {code: count(postal_code=code) for code in list_postal_codes()} == expected
+
+    def test_counts_what_the_lookup_actually_returns(self) -> None:
+        # The pool count() measures is the pool real_random_addresses draws from,
+        # so asking for exactly that many distinct addresses must not raise.
+        total = count(state="VA", city="Arlington")
+
+        assert len(real_random_addresses(total, state="VA", city="Arlington", seed=1)) == total
+
+    def test_state_matching_ignores_case_and_whitespace(self) -> None:
+        assert count(state="ca") == count(state="CA") == count(state="  Ca  ")
+
+    def test_city_matching_ignores_case_and_whitespace(self) -> None:
+        city = list_cities()[0]
+
+        assert count(city=city.upper()) == count(city=city.lower()) == count(city=f"  {city}  ")
+
+    def test_postal_code_is_matched_exactly(self) -> None:
+        code = list_postal_codes()[0]
+
+        assert count(postal_code=code) > 0
+        # A prefix is a different postal code, not a looser spelling of this one.
+        assert count(postal_code=code[:-1]) == 0
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"state": "CA"},
+            {"city": "Arlington"},
+            {"postal_code": "22204"},
+            {"state": "VA", "city": "Arlington"},
+            {"state": "ZZ"},
+        ],
+    )
+    def test_is_always_a_non_negative_int(self, filters: dict[str, str]) -> None:
+        result = count(**filters)
+
+        assert type(result) is int
+        assert result >= 0
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {"state": "ZZ"},
+            {"city": "Nowhere"},
+            {"postal_code": "00000"},
+            {"state": "ZZ", "city": "Nowhere"},
+            {"state": "ZZ", "city": "Nowhere", "postal_code": "00000"},
+            # Each value exists, but no single address carries both.
+            {"state": "CA", "city": "Arlington"},
+        ],
+    )
+    def test_counts_zero_when_nothing_matches(self, filters: dict[str, str]) -> None:
+        assert count(**filters) == 0
+
+    def test_no_match_counts_zero_rather_than_raising(self) -> None:
+        # real_random_address raises here; count answers the question instead.
+        with pytest.raises(NoMatchingAddressError):
+            real_random_address(state="ZZ")
+
+        assert count(state="ZZ") == 0
+
+    def test_filters_combine(self, dataset: InstallDataset) -> None:
+        dataset(
+            address(state="CA", city="Newark", postal_code="94560"),
+            address(state="CA", city="Fresno", postal_code="93650"),
+            address(state="FL", city="Newark", postal_code="32409"),
+        )
+
+        assert count() == 3
+        assert count(state="CA") == 2
+        assert count(city="Newark") == 2
+        assert count(postal_code="94560") == 1
+        assert count(state="CA", city="Newark") == 1
+        assert count(state="CA", postal_code="93650") == 1
+        assert count(city="Newark", postal_code="32409") == 1
+        assert count(state="CA", city="Newark", postal_code="94560") == 1
+
+    def test_narrowing_never_widens(self, dataset: InstallDataset) -> None:
+        dataset(
+            address(state="CA", city="Newark", postal_code="94560"),
+            address(state="CA", city="Newark", postal_code="94561"),
+            address(state="CA", city="Fresno", postal_code="93650"),
+        )
+
+        assert count(state="CA", city="Newark") <= count(state="CA")
+        assert count(state="CA", city="Newark", postal_code="94560") <= count(
+            state="CA", city="Newark"
+        )
+
+    def test_an_empty_dataset_counts_zero(self, dataset: InstallDataset) -> None:
+        dataset()
+
+        assert count() == 0
 
 
 class TestPackageSurface:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -37,9 +37,74 @@ ADDRESS_FIELDS = {"address1", "address2", "city", "state", "postal_code", "coord
 STATE = re.compile(r"^[A-Z]{2}$")
 POSTAL_CODE = re.compile(r"^\d{5}$")
 
+# The shape check above is happy with "ZZ". The dataset promises a real place,
+# so the code has to be one that exists. DC is included; the territories are not,
+# because nothing in the dataset claims one yet and admitting them here would
+# quietly widen the promise.
+US_STATES = frozenset(
+    {
+        "AL",
+        "AK",
+        "AZ",
+        "AR",
+        "CA",
+        "CO",
+        "CT",
+        "DE",
+        "DC",
+        "FL",
+        "GA",
+        "HI",
+        "ID",
+        "IL",
+        "IN",
+        "IA",
+        "KS",
+        "KY",
+        "LA",
+        "ME",
+        "MD",
+        "MA",
+        "MI",
+        "MN",
+        "MS",
+        "MO",
+        "MT",
+        "NE",
+        "NV",
+        "NH",
+        "NJ",
+        "NM",
+        "NY",
+        "NC",
+        "ND",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "SD",
+        "TN",
+        "TX",
+        "UT",
+        "VT",
+        "VA",
+        "WA",
+        "WV",
+        "WI",
+        "WY",
+    }
+)
+
 # Loose bounds covering the continental US, Alaska, Hawaii and Puerto Rico.
 MIN_LAT, MAX_LAT = 17.0, 72.0
 MIN_LNG, MAX_LNG = -180.0, -64.0
+
+# What a latitude and longitude can be at all, regardless of country. The US box
+# is strictly inside this, so these only fire on a truly nonsensical coordinate
+# such as a swapped lat/lng pair.
+LAT_LIMIT, LNG_LIMIT = 90.0, 180.0
 
 
 @pytest.fixture(scope="session")
@@ -50,6 +115,18 @@ def lines() -> list[str]:
 @pytest.fixture(scope="session")
 def records(lines: list[str]) -> list[Record]:
     return [json.loads(line) for line in lines]
+
+
+def duplicate_key(record: Record) -> tuple[str, ...]:
+    """Canonical identity of an address, for deciding whether two are the same.
+
+    Mirrors ``add_addresses._key`` so that what the ingest script skips as a
+    duplicate is exactly what this file refuses to ship.
+    """
+    return tuple(
+        " ".join(str(record.get(field, "")).split()).casefold()
+        for field in ("state", "city", "postal_code", "address1", "address2")
+    )
 
 
 def sort_key(record: Record) -> tuple[str, ...]:
@@ -105,6 +182,11 @@ class TestRecords:
         for record in records:
             assert STATE.match(record["state"]), record
 
+    def test_state_is_a_real_us_state_or_dc(self, records: list[Record]) -> None:
+        unknown = sorted({record["state"] for record in records} - US_STATES)
+
+        assert not unknown, f"dataset contains states that do not exist: {unknown}"
+
     def test_postal_code_is_five_digits(self, records: list[Record]) -> None:
         for record in records:
             assert POSTAL_CODE.match(record["postal_code"]), record
@@ -112,11 +194,22 @@ class TestRecords:
     def test_coordinates_are_finite_and_inside_the_us(self, records: list[Record]) -> None:
         for record in records:
             coordinates = record["coordinates"]
+            assert isinstance(coordinates, dict), record
             assert set(coordinates) == {"lat", "lng"}, record
 
             lat, lng = coordinates["lat"], coordinates["lng"]
+            # float, not "numeric": every record is written out as a float, and
+            # accepting an int here would let a truncated coordinate through.
             assert isinstance(lat, float) and isfinite(lat), record
             assert isinstance(lng, float) and isfinite(lng), record
+
+            # The global limits are redundant against the US box below, and that
+            # is the point: they state the contract the README documents, so a
+            # future non-US dataset loosening the box still cannot ship a
+            # swapped lat/lng pair.
+            assert -LAT_LIMIT <= lat <= LAT_LIMIT, record
+            assert -LNG_LIMIT <= lng <= LNG_LIMIT, record
+
             assert MIN_LAT <= lat <= MAX_LAT, record
             assert MIN_LNG <= lng <= MAX_LNG, record
 
@@ -164,15 +257,14 @@ class TestRecords:
         )
 
     def test_there_are_no_duplicate_addresses(self, records: list[Record]) -> None:
-        counts = Counter(
-            (
-                record["state"],
-                record["postal_code"],
-                record["address1"].casefold(),
-                record["address2"].casefold(),
-            )
-            for record in records
-        )
+        """Two records are the same address when their canonical keys match.
+
+        The key carries city as well as state, and collapses internal whitespace
+        as well as case, so "1  Main  Street" and "1 Main Street" cannot both
+        ship. address2 stays in the key because two apartments in one building
+        are different addresses; dropping it would discard real units.
+        """
+        counts = Counter(duplicate_key(record) for record in records)
         duplicates = [key for key, total in counts.items() if total > 1]
 
         assert not duplicates, f"duplicate addresses: {sorted(duplicates)[:5]}"


### PR DESCRIPTION
count() answers how many addresses match a filter without drawing one, reusing the same internal pool the lookup functions filter through so the two cannot disagree. It returns 0 where they raise.

Texas and Oregon bring the dataset to 3,400 addresses across 20 states, both from public-domain sources that do not require attribution.

The canonical duplicate key now carries city and collapses whitespace, and the ingest script accounts for every record it reads. No shipped record changed: the stronger key finds no duplicates in existing data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `count()` to report matching addresses by state, city, and postal code.
  * Added 100 addresses from Oregon and Texas.
* **Bug Fixes**
  * Improved duplicate detection by normalizing capitalization and whitespace.
  * Expanded dataset integrity checks and ingest reporting for clearer totals.
* **Documentation**
  * Updated usage examples, dataset statistics, source attributions, and function reference.
  * Added a roadmap outlining planned improvements.
* **Chores**
  * Released version 2.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->